### PR TITLE
fix: enable delivery flag on store when saving manual/express delivery locations

### DIFF
--- a/src/modules/shared/components/ManageManualDeliveryModal.vue
+++ b/src/modules/shared/components/ManageManualDeliveryModal.vue
@@ -89,6 +89,8 @@ import {
   useDeleteManualDeliveryOption,
   useDeleteExpressDeliveryOption,
 } from "@modules/shared/api"
+import { useUpdateStoreDetails } from "@modules/settings/api"
+import { useAuthStore } from "@modules/auth/store"
 import { toast } from "@/composables/useToast"
 import { displayError } from "@/utils/error-handler"
 
@@ -150,6 +152,8 @@ const { mutateAsync: updateManual } = useUpdateManualDeliveryOption()
 const { mutateAsync: updateExpress } = useUpdateExpressDeliveryOption()
 const { mutateAsync: deleteManual } = useDeleteManualDeliveryOption()
 const { mutateAsync: deleteExpress } = useDeleteExpressDeliveryOption()
+const { mutate: updateStoreDetails } = useUpdateStoreDetails()
+const storeUid = useAuthStore().user?.store_uid || ""
 
 const isLoading = computed(() =>
   props.mode === "express" ? isLoadingExpress.value : isLoadingManual.value,
@@ -258,6 +262,13 @@ const handleSave = async () => {
 
     // Clear pending deletions after successful save
     pendingDeletions.value = []
+
+    // Enable the corresponding delivery flag on the store
+    const enableFlag =
+      props.mode === "express"
+        ? { express_delivery_enabled: true }
+        : { manual_delivery_enabled: true }
+    updateStoreDetails({ id: storeUid, body: enableFlag })
 
     toast.success(
       `${props.mode === "express" ? "Express" : "Manual"} delivery settings saved successfully`,

--- a/src/modules/shared/views/onboarding.vue
+++ b/src/modules/shared/views/onboarding.vue
@@ -195,7 +195,7 @@ const tasks = computed(() => {
     {
       id: 4,
       title: "Allow Delivery?",
-      completed: criteria?.delivery_options?.details?.delivery_enabled || false,
+      completed: criteria?.delivery_options?.status || false,
       subtext: "Offer delivery to your customers.",
       isButton: false,
       buttonLabel: "",


### PR DESCRIPTION

- PATCH manual_delivery_enabled or express_delivery_enabled on the store after saving delivery locations in ManageManualDeliveryModal
- Check all three delivery flags in onboarding completion (delivery_enabled, manual_delivery_enabled, express_delivery_enabled)