### PR TITLE
fix: address qa feedback across inventory and delivery flows

### DIFF
--- a/src/components/form/MultiFileInput.vue
+++ b/src/components/form/MultiFileInput.vue
@@ -9,8 +9,13 @@
         'hover:border-primary-400 cursor-pointer border-gray-300 hover:bg-gray-50':
           !image && !isSlotDisabled(index),
         'cursor-not-allowed border-gray-200 bg-gray-50': !image && isSlotDisabled(index),
+        'border-primary-500 bg-primary-100': dragOverIndex === index && !isSlotDisabled(index),
       }"
       @click="!isSlotDisabled(index) && !processingSlots.has(index) && triggerFileInput(index)"
+      @dragenter.prevent="handleDragEnter(index)"
+      @dragover.prevent="handleDragOver(index)"
+      @dragleave.prevent="handleDragLeave(index)"
+      @drop.prevent="handleDrop($event, index)"
     >
       <!-- File input (hidden) -->
       <input
@@ -179,6 +184,41 @@ const images = reactive<(File | string | null)[]>(
 // Track which slots are currently processing
 const processingSlots = reactive<Set<number>>(new Set())
 
+// Index of the slot currently being dragged over (null when none) — LYW-2434
+const dragOverIndex = ref<number | null>(null)
+
+const handleDragEnter = (index: number) => {
+  if (isSlotDisabled.value(index) || processingSlots.has(index)) return
+  dragOverIndex.value = index
+}
+
+const handleDragOver = (index: number) => {
+  if (isSlotDisabled.value(index) || processingSlots.has(index)) return
+  dragOverIndex.value = index
+}
+
+const handleDragLeave = (index: number) => {
+  if (dragOverIndex.value === index) {
+    dragOverIndex.value = null
+  }
+}
+
+const handleDrop = async (event: DragEvent, index: number) => {
+  dragOverIndex.value = null
+  if (isSlotDisabled.value(index) || processingSlots.has(index)) return
+
+  const files = Array.from(event.dataTransfer?.files ?? [])
+  if (files.length === 0) return
+
+  // Reuse the existing file-processing pipeline by synthesising an Event with
+  // `target.files` so we don't duplicate validation/conversion logic.
+  const synthetic = {
+    target: { files, value: "" },
+  } as unknown as Event
+
+  await handleFileSelect(synthetic, index)
+}
+
 // Refs for file inputs
 const fileInputRefs = ref<(HTMLInputElement | null)[]>([])
 
@@ -250,8 +290,13 @@ const handleFileSelect = async (event: Event, startIndex: number) => {
 
   if (files.length === 0) return
 
-  // Calculate how many slots are available from the clicked position
-  const availableSlots = props.numberOfImages - startIndex
+  // Calculate how many slots are available from the clicked position. In
+  // product image mode, slots beyond `enabledSlots` are Bloom-gated and must
+  // not accept uploads — cap by the lower of (numberOfImages, enabledSlots).
+  const enabledLimit = props.productImageMode
+    ? Math.min(props.numberOfImages, props.enabledSlots ?? props.numberOfImages)
+    : props.numberOfImages
+  const availableSlots = Math.max(0, enabledLimit - startIndex)
 
   // Show error if too many files were uploaded
   if (files.length > availableSlots) {
@@ -266,33 +311,36 @@ const handleFileSelect = async (event: Event, startIndex: number) => {
     const file = filesToProcess[fileIndex]
     const targetIndex = startIndex + fileIndex
 
-    if (targetIndex < props.numberOfImages) {
-      const validationError = validateFile(file)
+    // Defensive: skip disabled slots even if the cap above missed them (e.g.
+    // future code that disables non-trailing slots).
+    if (targetIndex >= props.numberOfImages || isSlotDisabled.value(targetIndex)) continue
 
-      if (validationError) {
-        toast.error(validationError)
-      } else {
-        let processedFile = file
+    const validationError = validateFile(file)
 
-        // Convert and compress in product image mode
-        if (props.productImageMode) {
-          processingSlots.add(targetIndex)
-          try {
-            processedFile = await convertAndCompressImage(file)
-          } catch (error) {
-            console.error("Failed to process image:", error)
-            const errorMessage = error instanceof Error ? error.message : "Failed to process image"
-            toast.error(errorMessage)
-            processingSlots.delete(targetIndex)
-            // Skip this file on error
-            continue
-          }
-          processingSlots.delete(targetIndex)
-        }
-
-        images[targetIndex] = processedFile
-      }
+    if (validationError) {
+      toast.error(validationError)
+      continue
     }
+
+    let processedFile = file
+
+    // Convert and compress in product image mode
+    if (props.productImageMode) {
+      processingSlots.add(targetIndex)
+      try {
+        processedFile = await convertAndCompressImage(file)
+      } catch (error) {
+        console.error("Failed to process image:", error)
+        const errorMessage = error instanceof Error ? error.message : "Failed to process image"
+        toast.error(errorMessage)
+        processingSlots.delete(targetIndex)
+        // Skip this file on error
+        continue
+      }
+      processingSlots.delete(targetIndex)
+    }
+
+    images[targetIndex] = processedFile
   }
 
   // Clear the file input

--- a/src/composables/useUserRoles.ts
+++ b/src/composables/useUserRoles.ts
@@ -1,0 +1,20 @@
+import { computed } from "vue"
+import { useAuthStore } from "@modules/auth/store"
+
+const STOCK_VALUE_ALLOWED_ROLES = ["owner", "manager", "finance"] as const
+
+/** Centralized role checks. Add helpers here as new role gates emerge. */
+export function useUserRoles() {
+  const authStore = useAuthStore()
+
+  const isOwner = computed(() => authStore.user?.roles?.some((r) => r.type === "owner") ?? false)
+
+  const canViewStockValue = computed(
+    () =>
+      authStore.user?.roles?.some((r) =>
+        (STOCK_VALUE_ALLOWED_ROLES as readonly string[]).includes(r.type),
+      ) ?? false,
+  )
+
+  return { isOwner, canViewStockValue }
+}

--- a/src/modules/inventory/components/FilterDrawer.vue
+++ b/src/modules/inventory/components/FilterDrawer.vue
@@ -135,7 +135,6 @@ const statusOptions = [
   { value: "in_stock", label: "In Stock", color: "success" as const },
   { value: "out_of_stock", label: "Out of Stock", color: "error" as const },
   { value: "low_stock", label: "Low Stock", color: "warning" as const },
-  { value: "overstocked", label: "Overstocked", color: "primary" as const },
 ]
 
 // Selected status state

--- a/src/modules/inventory/components/ProductEditDrawer.vue
+++ b/src/modules/inventory/components/ProductEditDrawer.vue
@@ -777,10 +777,13 @@ const handleSubmit = async () => {
             toast.success(
               `All ${variantDetailsWithUids.value.length} variants updated successfully`,
             )
-            queryClient.invalidateQueries({ queryKey: ["products"] })
-            submitAttempted.value = false
-            emit("update:modelValue", false)
-            emit("refresh")
+            // LYW-2442: force a refetch (not just invalidate) so the parent
+            // details overview reflects the new price without a page reload.
+            void queryClient.refetchQueries({ queryKey: ["products"] }).finally(() => {
+              submitAttempted.value = false
+              emit("update:modelValue", false)
+              emit("refresh")
+            })
           },
           onError: displayError,
         },
@@ -802,10 +805,12 @@ const handleSubmit = async () => {
         {
           onSuccess: () => {
             toast.success("Variant updated successfully")
-            queryClient.invalidateQueries({ queryKey: ["products"] })
-            submitAttempted.value = false
-            emit("update:modelValue", false)
-            emit("refresh")
+            // LYW-2442: force a refetch so price changes show without reload.
+            void queryClient.refetchQueries({ queryKey: ["products"] }).finally(() => {
+              submitAttempted.value = false
+              emit("update:modelValue", false)
+              emit("refresh")
+            })
           },
           onError: displayError,
         },

--- a/src/modules/inventory/components/ProductForm/ProductManageCombinationsForm.vue
+++ b/src/modules/inventory/components/ProductForm/ProductManageCombinationsForm.vue
@@ -198,6 +198,14 @@
               "
               @blur="handleStockBlur(index, $event)"
             />
+            <button
+              v-if="index === 0 && variants.length > 1 && variant.opening_stock"
+              type="button"
+              class="text-primary-600 mt-1 block w-full truncate text-[10px] underline"
+              @click="applyToAll('opening_stock', variant.opening_stock)"
+            >
+              Apply to all
+            </button>
           </div>
 
           <!-- Cost Price Input -->
@@ -219,6 +227,16 @@
               "
               @blur="handleCostPriceBlur(index, $event)"
             />
+            <button
+              v-if="
+                index === 0 && variants.length > 1 && !props.disableCostPrice && variant.cost_price
+              "
+              type="button"
+              class="text-primary-600 mt-1 block w-full truncate text-[10px] underline"
+              @click="applyToAll('cost_price', variant.cost_price)"
+            >
+              Apply to all
+            </button>
           </div>
 
           <!-- Selling Price Input -->
@@ -238,6 +256,14 @@
               @update:model-value="updateVariantField(index, 'price', removeLeadingZeros($event))"
               @blur="handlePriceBlur(index, $event)"
             />
+            <button
+              v-if="index === 0 && variants.length > 1 && !props.disablePrice && variant.price"
+              type="button"
+              class="text-primary-600 mt-1 block w-full truncate text-[10px] underline"
+              @click="applyToAll('price', variant.price)"
+            >
+              Apply to all
+            </button>
           </div>
         </div>
       </div>
@@ -284,6 +310,14 @@
               "
               @blur="handleStockBlur(index, $event)"
             />
+            <button
+              v-if="index === 0 && variants.length > 1 && variant.opening_stock"
+              type="button"
+              class="text-primary-600 mt-1 text-xs underline"
+              @click="applyToAll('opening_stock', variant.opening_stock)"
+            >
+              Apply to all
+            </button>
           </div>
 
           <!-- Cost Price -->
@@ -306,6 +340,16 @@
               "
               @blur="handleCostPriceBlur(index, $event)"
             />
+            <button
+              v-if="
+                index === 0 && variants.length > 1 && !props.disableCostPrice && variant.cost_price
+              "
+              type="button"
+              class="text-primary-600 mt-1 text-xs underline"
+              @click="applyToAll('cost_price', variant.cost_price)"
+            >
+              Apply to all
+            </button>
           </div>
 
           <!-- Selling Price -->
@@ -326,6 +370,14 @@
               @update:model-value="updateVariantField(index, 'price', removeLeadingZeros($event))"
               @blur="handlePriceBlur(index, $event)"
             />
+            <button
+              v-if="index === 0 && variants.length > 1 && !props.disablePrice && variant.price"
+              type="button"
+              class="text-primary-600 mt-1 text-xs underline"
+              @click="applyToAll('price', variant.price)"
+            >
+              Apply to all
+            </button>
             <p v-if="costPriceWarnings[index]" class="mt-1 text-xs text-amber-600">
               {{ costPriceWarnings[index] }}
             </p>
@@ -459,10 +511,33 @@ const currencySymbol = computed(() => {
   return symbols[currency] || currency
 })
 
+/**
+ * Parse a price-shaped value, tolerating thousands separators and stray
+ * whitespace. `parseFloat("1,000")` returns 1, which caused LYW-2508 — the
+ * warning fired with cost=10, sell=1,000 because sell parsed to 1.
+ */
+const parsePrice = (val: string | number | null | undefined): number => {
+  if (val === null || val === undefined) return NaN
+  const str = (typeof val === "number" ? val.toString() : val).trim().replace(/[^\d.-]/g, "")
+  if (!str) return NaN
+  return parseFloat(str)
+}
+
 const costPriceWarnings = computed(() => {
-  return variants.value.map((v) => {
-    const cost = parseFloat(v.cost_price)
-    const sell = parseFloat(v.price)
+  return variants.value.map((v, i) => {
+    const cost = parsePrice(v.cost_price)
+    const sell = parsePrice(v.price)
+    // TEMP LYW-2508 INVESTIGATION: log raw values so the source of any
+    // comma-formatted prices can be traced. Remove once confirmed clean.
+    if (
+      typeof v.cost_price === "string" &&
+      (v.cost_price.includes(",") || /\s/.test(v.cost_price))
+    ) {
+      console.warn(`[LYW-2508] variant[${i}].cost_price contains separators:`, v.cost_price)
+    }
+    if (typeof v.price === "string" && (v.price.includes(",") || /\s/.test(v.price))) {
+      console.warn(`[LYW-2508] variant[${i}].price contains separators:`, v.price)
+    }
     if (isFinite(cost) && isFinite(sell) && cost > 0 && sell > 0 && sell < cost) {
       return "Note: Selling price is lower than cost price"
     }
@@ -619,6 +694,20 @@ const updateVariantField = (index: number, field: keyof IProductVariant, value: 
     }
     emit("update:modelValue", updatedVariants)
   }
+}
+
+/**
+ * LYW-2509: copy a field's value from the first variant to every other variant,
+ * overwriting whatever the others hold. Used by the "Apply to all" link shown
+ * below each price/cost/stock field on the first variant.
+ */
+const applyToAll = (field: "opening_stock" | "cost_price" | "price", value: string) => {
+  if (!props.modelValue || props.modelValue.length < 2) return
+  const updatedVariants = props.modelValue.map((variant, index) => {
+    if (index === 0) return variant
+    return { ...variant, [field]: value }
+  })
+  emit("update:modelValue", updatedVariants)
 }
 
 // Update global dimensions and apply to all variants

--- a/src/modules/inventory/components/ProductFormDrawer.vue
+++ b/src/modules/inventory/components/ProductFormDrawer.vue
@@ -11,7 +11,10 @@
     <IconHeader icon-name="shop-add" :title="getHeaderTitle" :subtext="getHeaderText" />
 
     <form id="product-form" @submit.prevent="handleSubmit" class="min-h-full">
-      <div>
+      <!-- LYW-2443: skeleton while the source product is being fetched -->
+      <ProductEditSkeleton v-if="isLoadingDuplicate" />
+
+      <div v-else>
         <!-- Step 1: Product Details -->
         <ProductDetailsForm
           v-if="step === 1"
@@ -93,18 +96,20 @@ import ProductManageCombinationsForm from "./ProductForm/ProductManageCombinatio
 import ProductImagesForm from "./ProductForm/ProductImagesForm.vue"
 import ProductVariantsForm from "./ProductForm/ProductVariantsForm.vue"
 import AddCategoryModal from "./AddCategoryModal.vue"
+import ProductEditSkeleton from "./skeletons/ProductEditSkeleton.vue"
 import {
   useCreateProduct,
   useCreateAttribute,
   useCreateAttributeValues,
   useAddProductImage,
   useUpdateVariantImage,
+  useGetProduct,
 } from "../api"
 import baseApi from "@/composables/baseApi"
 import { displayError } from "@/utils/error-handler"
 import { toast } from "@/composables/useToast"
 import { useQueryClient } from "@tanstack/vue-query"
-import { htmlToMarkdown } from "@/utils/html-to-markdown"
+import { htmlToMarkdown, markdownToHtml } from "@/utils/html-to-markdown"
 import { useImageConverter } from "@/composables/useImageConverter"
 import { useAuthStore } from "@modules/auth/store"
 import { scrollToAndFocusValidationTarget } from "@/utils/validations"
@@ -123,6 +128,11 @@ interface Props {
   modelValue: boolean
   /** Loading state for async operations */
   loading?: boolean
+  /** UID of a product to duplicate. When set, the form is prefilled with that
+   *  product's data: name suffixed with " (Copy)", opening stock reset to 0,
+   *  images left blank for the user to re-upload (carry-over is gated on a
+   *  CORS config on the DO Spaces bucket — see prefillFromSource). */
+  sourceProductUid?: string | null
 }
 
 interface Emits {
@@ -134,6 +144,7 @@ interface Emits {
 
 const props = withDefaults(defineProps<Props>(), {
   loading: false,
+  sourceProductUid: null,
 })
 
 const emit = defineEmits<Emits>()
@@ -158,7 +169,8 @@ const { mutateAsync: updateVariantImage, isPending: isUpdatingVariantImage } =
   useUpdateVariantImage()
 
 // Composables
-const { form, hasVariants, variants, variantConfiguration, resetFormState } = useProductFormState()
+const { form, hasVariants, variants, variantConfiguration, resetFormState, populateFormState } =
+  useProductFormState()
 
 const queryClient = useQueryClient()
 const { renameProductImage } = useImageConverter()
@@ -204,7 +216,8 @@ const isPending = computed(() => {
     isCreatingAttribute.value ||
     isCreatingAttributeValues.value ||
     isAddingProductImages.value ||
-    isUpdatingVariantImage.value
+    isUpdatingVariantImage.value ||
+    isPreparingDuplicateImages.value
   )
 })
 
@@ -220,16 +233,222 @@ const handleCategoryCreated = (category: { label: string; value: string }) => {
   }
 }
 
-// Watch for drawer opening to reset form
+// LYW-2443: fetch the source product when in duplicate mode
+const sourceUidRef = computed(() => props.sourceProductUid || "")
+const { data: sourceProductData, isFetching: isFetchingSource } = useGetProduct(sourceUidRef, {
+  enabled: computed(() => !!props.sourceProductUid && props.modelValue),
+})
+
+// While true, fetching source images and converting them to File objects.
+// Used to keep the skeleton visible during this phase and to gate the submit
+// button via isPending.
+const isPreparingDuplicateImages = ref(false)
+
+// Show a loading state in the drawer body while we wait for source data on
+// first open AND while we're converting source image URLs to File objects.
+// Once both finish (or for a non-duplicate flow), we render the prefilled form.
+const isLoadingDuplicate = computed(
+  () =>
+    !!props.sourceProductUid &&
+    props.modelValue &&
+    ((isFetchingSource.value && !sourceProductData.value) || isPreparingDuplicateImages.value),
+)
+
+/**
+ * Build the populate payload from a fetched source product. Extracted so it
+ * can be invoked both from the sourceProductData watcher (when data arrives
+ * async) and from the modelValue watcher (when data is already cached on a
+ * subsequent open of the same source product).
+ */
+const prefillFromSource = (data: typeof sourceProductData.value) => {
+  if (!data?.data || !props.modelValue || !props.sourceProductUid) return
+  const src = data.data
+
+  // Image carry-over is temporarily disabled: the source images are served
+  // from a DigitalOcean Spaces bucket that doesn't return CORS headers, so
+  // `fetch()` can't read them in the browser. Once CORS is configured on the
+  // bucket, swap `images: []` for `images: [...productImages, ...variantImages]`
+  // (the URL gatherers below) and the existing convertSourceImagesToFiles
+  // pipeline takes over without further changes.
+  //
+  // const productImages =
+  //   src.images && src.images.length > 0
+  //     ? [
+  //         ...src.images
+  //           .slice()
+  //           .sort((a, b) => a.sort_order - b.sort_order)
+  //           .slice(0, 5)
+  //           .map((img) => img.image),
+  //         ...Array(Math.max(0, 5 - src.images.length)).fill(null),
+  //       ]
+  //     : Array(5).fill(null)
+  // const variantImages =
+  //   src.variants && src.variants.length > 0
+  //     ? src.variants.map((variant) => variant.image || null)
+  //     : []
+
+  populateFormState({
+    name: `${src.name || ""} (Copy)`,
+    description: markdownToHtml(src.description || ""),
+    story: src.story || "",
+    brand: src.brand || "",
+    requires_approval: src.requires_approval || false,
+    category: src.category ? { label: src.category_name || "", value: src.category } : null,
+    images: [], // see CORS note above; user uploads images manually for now
+    hasVariants: src.is_variable || false,
+    variants:
+      src.variants?.map((variant) => ({
+        name: variant.name || "",
+        sku: "", // Force a new SKU on submit
+        price: variant.price || "",
+        promo_price: variant.promo_price || "",
+        promo_expiry: variant.promo_expiry || "",
+        cost_price: variant.cost_price || "",
+        weight: variant.weight || "",
+        length: variant.length || "",
+        width: variant.width || "",
+        height: variant.height || "",
+        reorder_point:
+          variant.reorder_point !== null && variant.reorder_point !== undefined
+            ? variant.reorder_point.toString()
+            : "",
+        max_stock:
+          variant.max_stock !== null && variant.max_stock !== undefined
+            ? variant.max_stock.toString()
+            : "",
+        opening_stock: "0",
+        is_active: variant.is_active ?? true,
+        is_default: variant.is_default ?? false,
+        batch_number: "",
+        expiry_date: variant.expiry_date || "",
+        attributes: variant.attributes || [],
+      })) || undefined,
+    variantConfiguration:
+      src.is_variable && src.variants && src.variants.length > 1
+        ? (() => {
+            const attributeMap = new Map<
+              string,
+              {
+                attributeUid: string
+                attributeName: string
+                values: Map<string, string>
+              }
+            >()
+            src.variants.forEach((variant) => {
+              variant.attributes.forEach((attr) => {
+                if (!attributeMap.has(attr.attribute)) {
+                  attributeMap.set(attr.attribute, {
+                    attributeUid: attr.attribute,
+                    attributeName: attr.attribute_name,
+                    values: new Map(),
+                  })
+                }
+                attributeMap.get(attr.attribute)!.values.set(attr.value, attr.attribute_value)
+              })
+            })
+            return Array.from(attributeMap.values()).map((attrData) => ({
+              name: { label: attrData.attributeName, value: attrData.attributeUid },
+              customName: "",
+              values: Array.from(attrData.values.entries()).map(([valueUid, valueName]) => ({
+                label: valueName,
+                value: valueUid,
+              })),
+            }))
+          })()
+        : undefined,
+  })
+}
+
+/**
+ * LYW-2443: convert any URL-string entries in `form.images` to File objects
+ * by fetching each URL and wrapping its blob. Runs in parallel.
+ *
+ * The image upload endpoint accepts only File via FormData, so this MUST run
+ * before submit. We do it eagerly right after prefill (while the skeleton is
+ * still visible) rather than on submit so the user has clear visibility:
+ *   - If a URL can't be fetched (CORS, network, server-side error page), the
+ *     slot drops to null. The user sees the blank slot in step 3/4 and can
+ *     re-upload manually.
+ *   - We toast a single summary if any failed, so the user knows.
+ */
+const convertSourceImagesToFiles = async (): Promise<void> => {
+  const tasks: Array<Promise<{ index: number; ok: boolean }>> = []
+  for (let i = 0; i < form.images.length; i++) {
+    const img = form.images[i]
+    if (typeof img !== "string" || !img) continue
+    const index = i
+    const url = img
+    tasks.push(
+      (async () => {
+        try {
+          const response = await fetch(url)
+          if (!response.ok) throw new Error(`HTTP ${response.status}`)
+          const blob = await response.blob()
+          // Reject anything that isn't actually an image (e.g. a CORS-redirect
+          // HTML error page that returned 200).
+          if (!blob.type.startsWith("image/")) {
+            throw new Error(`Unexpected MIME type: ${blob.type || "unknown"}`)
+          }
+          const filename = url.split("/").pop()?.split("?")[0] || `duplicate-image-${index}.jpg`
+          form.images[index] = new File([blob], filename, { type: blob.type })
+          return { index, ok: true }
+        } catch (err) {
+          console.warn(`[LYW-2443] Failed to carry over source image at index ${index}:`, err)
+          form.images[index] = null
+          return { index, ok: false }
+        }
+      })(),
+    )
+  }
+  if (tasks.length === 0) return
+  const results = await Promise.all(tasks)
+  const failed = results.filter((r) => !r.ok).length
+  if (failed > 0) {
+    toast.info(
+      failed === results.length
+        ? "Source product images couldn't be carried over. Please upload them on the Images step."
+        : `${failed} of ${results.length} source image${results.length === 1 ? "" : "s"} couldn't be carried over. Please re-upload missing slots on the Images step.`,
+    )
+  }
+}
+
+/**
+ * Run prefill + (when in duplicate mode) eager image conversion. Keeping this
+ * single function ensures the skeleton stays visible until everything is ready.
+ */
+const runPrefillAndConvertImages = async (data: typeof sourceProductData.value) => {
+  if (!data?.data || !props.modelValue || !props.sourceProductUid) return
+  prefillFromSource(data)
+  isPreparingDuplicateImages.value = true
+  try {
+    await convertSourceImagesToFiles()
+  } finally {
+    isPreparingDuplicateImages.value = false
+  }
+}
+
+// Reset form on drawer open, then re-apply prefill if cached source data is
+// already available (handles the case where useGetProduct returns cached data
+// synchronously and the data watcher doesn't fire on subsequent opens).
 watch(
   () => props.modelValue,
   (isOpen) => {
-    if (isOpen) {
-      resetFormState()
-      submitAttempted.value = false
+    if (!isOpen) return
+    resetFormState()
+    submitAttempted.value = false
+    if (props.sourceProductUid && sourceProductData.value) {
+      void runPrefillAndConvertImages(sourceProductData.value)
     }
   },
   { immediate: true },
+)
+
+// When source product data arrives async (cache miss), prefill + convert.
+watch(
+  () => sourceProductData.value,
+  (data) => {
+    void runPrefillAndConvertImages(data)
+  },
 )
 
 // Watch for step changes to scroll to top
@@ -251,6 +470,13 @@ const handleSubmit = async () => {
   }
 
   if (isLastStep.value) {
+    // Defensive: if a source-image conversion is somehow still in flight (the
+    // skeleton normally prevents the user reaching submit, but reactivity is
+    // async), wait for it before proceeding so we never submit a string URL.
+    while (isPreparingDuplicateImages.value) {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+
     // Format product data according to API schema
     const payload: IProductFormPayload = {
       name: form.name,

--- a/src/modules/inventory/components/ProductVariants.vue
+++ b/src/modules/inventory/components/ProductVariants.vue
@@ -33,13 +33,13 @@
           @click="showFilter = true"
         />
         <AppButton
-          icon="add"
+          icon="edit"
           size="sm"
           label="Manage Variants"
           class="!hidden md:!inline-flex"
           @click="$emit('add-variant')"
         />
-        <AppButton icon="add" size="sm" label="" class="md:hidden" @click="$emit('add-variant')" />
+        <AppButton icon="edit" size="sm" label="" class="md:hidden" @click="$emit('add-variant')" />
       </div>
     </div>
 
@@ -179,7 +179,6 @@ const filterGroups: FilterGroup[] = [
       { value: "in_stock", label: "In Stock", color: "success", showDot: true },
       { value: "low_stock", label: "Low Stock", color: "warning", showDot: true },
       { value: "out_of_stock", label: "Out of Stock", color: "error", showDot: true },
-      { value: "overstocked", label: "Overstocked", color: "primary", showDot: true },
     ],
   },
 ]

--- a/src/modules/inventory/views/index.vue
+++ b/src/modules/inventory/views/index.vue
@@ -228,6 +228,7 @@
     <ProductFormDrawer
       v-if="showProductFormDrawer"
       v-model="showProductFormDrawer"
+      :source-product-uid="productUidForDuplicate"
       @refresh="refetchProducts"
     />
     <ProductEditDrawer
@@ -290,7 +291,7 @@ import ReceiveRequestModal from "../components/ReceiveRequestModal.vue"
 import ProductCard from "../components/ProductCard.vue"
 import ManageStockModal from "../components/ManageStockModal.vue"
 import { useFormatCurrency } from "@/composables/useFormatCurrency"
-import { useAuthStore } from "@modules/auth/store"
+import { useUserRoles } from "@/composables/useUserRoles"
 import SectionHeader from "@components/SectionHeader.vue"
 import PageHeader from "@components/PageHeader.vue"
 import Tabs from "@components/Tabs.vue"
@@ -422,6 +423,8 @@ const productEditDrawerRef = ref<{
 
 // Manage stock modal state
 const showManageStockModal = ref(false)
+// LYW-2443: holds the source product UID when "Duplicate Product" is clicked
+const productUidForDuplicate = ref<string | null>(null)
 const editMode = ref<"product-details" | "variant-details" | "variants" | "images">(
   "product-details",
 )
@@ -498,7 +501,7 @@ const handleRowClick = (clickedProduct: TProduct) => {
   router.push({ name: "Product-Details", params: { uid: clickedProduct.uid } })
 }
 
-const isOwner = computed(() => useAuthStore().user?.roles?.some((r) => r.type === "owner") ?? false)
+const { canViewStockValue } = useUserRoles()
 
 const productMetrics = computed(() => {
   const stats = productDashboard.value
@@ -511,7 +514,7 @@ const productMetrics = computed(() => {
       iconClass: "text-success-500",
       percentage: 0,
     },
-    ...(isOwner.value
+    ...(canViewStockValue.value
       ? [
           {
             label: "Stock Value",
@@ -700,7 +703,9 @@ const handleAction = (
   } else if (action === "view") {
     router.push({ name: "Product-Details", params: { uid: item.uid } })
   } else if (action === "duplicate") {
-    toast.info("Duplicate functionality coming soon")
+    if (!checkPremiumAccess()) return
+    productUidForDuplicate.value = item.uid
+    showProductFormDrawer.value = true
   }
 }
 
@@ -787,8 +792,11 @@ watch(
 )
 
 watch(showProductFormDrawer, (isOpen) => {
-  if (!isOpen && route.query.create === "true") {
-    router.replace({ name: "Inventory", query: {} })
+  if (!isOpen) {
+    productUidForDuplicate.value = null
+    if (route.query.create === "true") {
+      router.replace({ name: "Inventory", query: {} })
+    }
   }
 })
 

--- a/src/modules/inventory/views/single.vue
+++ b/src/modules/inventory/views/single.vue
@@ -289,6 +289,11 @@ const openStockModal = (
 const handleStockSuccess = () => {
   queryClient.refetchQueries({ queryKey: ["products", uid] })
   queryClient.invalidateQueries({ queryKey: ["products"] })
+  // The Variants tab uses a separate query (`useGetVariantsByProduct` →
+  // `["product-variants-filtered", params]`), which the products invalidation
+  // doesn't reach. Refetch it explicitly so stock changes show without a page
+  // reload.
+  queryClient.refetchQueries({ queryKey: ["product-variants-filtered"] })
   refetchMovements()
 }
 

--- a/src/modules/settings/views/delivery-options.vue
+++ b/src/modules/settings/views/delivery-options.vue
@@ -369,7 +369,12 @@ const handleRefresh = () => {
 
           <!-- Standard Delivery Section -->
           <div>
-            <h3 class="text-md !font-outfit mb-3 font-semibold">Standard Delivery</h3>
+            <div class="mb-3 flex flex-wrap items-baseline gap-x-2">
+              <h3 class="text-md !font-outfit font-semibold">Standard Delivery</h3>
+              <p class="text-core-600 text-xs">
+                Choose between Managed Delivery or Manual Delivery
+              </p>
+            </div>
 
             <!-- Case 1: No shipping account AND no manual deliveries - Show setup prompt -->
             <div
@@ -411,7 +416,7 @@ const handleRefresh = () => {
 
                   <div class="flex-1">
                     <h3 class="mb-1 flex items-end gap-2 text-base font-semibold">
-                      Allow Managed Delivery?
+                      Use Managed Delivery?
                       <button
                         v-if="form.delivery_enabled || hasShippingAccount"
                         type="button"
@@ -455,7 +460,7 @@ const handleRefresh = () => {
                       </div>
                     </div>
                     <div class="flex flex-col">
-                      <h6 class="text-md font-semibold">Switch to Manual Delivery Service</h6>
+                      <h6 class="text-md font-semibold">Switch to Manual Delivery</h6>
                       <p class="text-sm">
                         Manage the delivery of orders to your customers all by yourself.
                       </p>
@@ -479,7 +484,7 @@ const handleRefresh = () => {
 
                   <div class="flex-1">
                     <h3 class="mb-1 flex items-end gap-2 text-base font-semibold">
-                      Allow Manual Delivery?
+                      Use Manual Delivery?
                       <button
                         v-if="form.manual_delivery_enabled || hasManualDeliveries"
                         type="button"
@@ -551,7 +556,7 @@ const handleRefresh = () => {
 
                 <div class="flex-1">
                   <h3 class="mb-1 flex items-end gap-2 text-base font-semibold">
-                    Allow Express Delivery?
+                    Add Express Delivery?
                     <button
                       v-if="form.express_delivery_enabled || hasExpressDeliveries"
                       type="button"


### PR DESCRIPTION
## Summary

Tackles the current sprint's QA backlog: 13 tickets across the inventory module, the
delivery options page, and the shared multi-file input component.

| Ticket | What changed |
|---|---|
| LYW-2444 | "Allow Managed/Manual Delivery?" → "Use Managed/Manual Delivery?" |
| LYW-2445 | "Allow Express Delivery?" → "Add Express Delivery?" |
| LYW-2446 | "Switch to Manual Delivery Service" → "Switch to Manual Delivery" (the Managed banner kept the trailing "Service" per the ticket) |
| LYW-2447 | Added a helper note next to the Standard Delivery heading |
| LYW-2435 | Dropped "Overstocked" from the inventory list and variants filters. **Mobile floating bottom sheet portion is still outstanding** — couldn't reproduce headlessly; needs a screenshot or DevTools inspection |
| LYW-2436 | Inventory summary cards confirmed in correct order: Total Products, Stock Value, Low Stock, Stale Products |
| LYW-2437 | Stock Value card hidden for non-Owner/Manager/Finance roles via a new `useUserRoles` composable |
| LYW-2434 | Drag-and-drop now works on `MultiFileInput`. Capacity capped by `enabledSlots`, disabled (Bloom-gated) slots skipped defensively |
| LYW-2439 | Manage Variants button icon swapped from `add` to `edit` on both desktop and mobile (the action is edit, not add) |
| LYW-2508 | Price comparison warning was firing wrongly for cost=10 / sell=1,000. Root cause: `parseFloat("1,000") === 1`. Added a `parsePrice` helper that strips non-digit chars before parsing. Investigation `console.warn`s left in temporarily — see "Things to verify" below |
| LYW-2442 | Variant price/stock updates: `refetchQueries` (not just `invalidate`) on the products query *and* on `product-variants-filtered`, so the overview, list, and Variants tab table all refresh without a page reload |
| LYW-2443 | Product duplicate is functional. Drawer prefills from the source product with a `(Copy)` name suffix, opening stock reset to 0, skeleton loader during fetch. Image carry-over implementation is wired in but **disabled in `prefillFromSource`** — the DigitalOcean Spaces bucket needs CORS configured before it can run; flipping it back on is a one-line change. See "Follow-ups" |
| LYW-2509 | "Apply to all" link below price/cost/stock fields on the first variant; copies that field's value to every other variant (overwriting, not just empty siblings) |

## File map

- `src/composables/useUserRoles.ts` — new composable, exposes `isOwner` and `canViewStockValue`
- `src/modules/settings/views/delivery-options.vue` — copy changes + helper note
- `src/modules/inventory/views/index.vue` — Stock Value role gate, duplicate handler wiring
- `src/modules/inventory/views/single.vue` — refetch `product-variants-filtered` on stock success
- `src/modules/inventory/components/FilterDrawer.vue` — drop Overstocked
- `src/modules/inventory/components/ProductVariants.vue` — drop Overstocked + edit icon
- `src/modules/inventory/components/ProductFormDrawer.vue` — duplicate prefill, skeleton, image carry-over scaffolding
- `src/modules/inventory/components/ProductEditDrawer.vue` — refetch on variant updates
- `src/modules/inventory/components/ProductForm/ProductManageCombinationsForm.vue` — `parsePrice` defensive parse, apply-to-all
- `src/components/form/MultiFileInput.vue` — drag-and-drop wiring

## Things to verify

These need a real browser session — flagging so reviewers/QA know what to look at:

- **LYW-2508 console logs.** Temporary `console.warn("[LYW-2508] variant[i].cost_price contains separators: …")` lines in `ProductManageCombinationsForm.vue` log if any price field gets a comma-formatted value into the model state. Reproduce the bug, check the console: if no warnings fire, the `parsePrice` defensive parse is belt-and-suspenders and the logs can come out in a follow-up. If they do fire, we know which path is letting commas through and can patch the upstream.
- **LYW-2435 mobile floating bottom sheet.** The Overstocked filter portion is fixed; the mobile bottom-sheet portion needs DevTools inspection (mobile width, product details page, identify the floating element).
- **LYW-2443 image carry-over.** Currently disabled because the DO Spaces bucket (`fra1.digitaloceanspaces.com/leyyow-crm`) doesn't return CORS headers, so client-side `fetch()` can't read the bytes. The conversion infrastructure (`convertSourceImagesToFiles`, validation, error toasts) is left in place; once Desmond configures CORS on the bucket, swap `images: []` for `images: [...productImages, ...variantImages]` in `prefillFromSource` and the existing pipeline takes over.

## Test plan

- Settings → Delivery Options (mobile + desktop): helper note next to Standard Delivery; "Use" instead of "Allow" on the toggles; "Switch to Manual Delivery" without the trailing "Service"; "Switch to Managed Delivery Service" still has it; "Add Express Delivery?"
- Inventory list filter (mobile + desktop): no Overstocked option in Status
- Product details → Variants tab: no Overstocked in the filter; edit icon (not +) on the Manage Variants button
- Inventory summary as Owner / Manager / Finance: 4 cards including Stock Value. As another role: 3 cards, Stock Value hidden, grid switches to 3-col on lg
- Add Product → step 4 Images: drag a file from the OS file manager onto a slot — preview shows; click upload still works; dragging onto a Bloom-gated slot is rejected
- Add Product → Inventory & Pricing: cost = 10, sell = 1,000 → no spurious "selling lower than cost" warning. Cost = 1,000, sell = 10 → warning fires (correct case)
- Add Product with multiple variants → first variant has "Apply to all" links below quantity, cost price, selling price; clicking copies that value to every other variant
- Edit Price & Weight on a single-variant and on a multi-variant product: price updates show on the overview without a page reload
- Stock add/reduce on a variant via the Variants tab: stock count refreshes in the table without a page reload
- Inventory → action menu → Duplicate Product: drawer opens with skeleton, then prefills name "Original (Copy)", category, description, variants, prices, opening stock = 0. Image slots are blank (carry-over disabled until bucket CORS). Submitting creates a new product

## Follow-ups (not in this PR)

- Configure CORS on the `leyyow-crm` Spaces bucket (Desmond) so the duplicate flow can carry over images. After that lands, flip the one-line in `prefillFromSource` and verify
- LYW-2435 mobile bottom sheet — not been able to figure it out yet.