### PR TITLE
fix: improve stock loading and product pagination

### DIFF
--- a/src/modules/discounts/components/TargetSelector.spec.ts
+++ b/src/modules/discounts/components/TargetSelector.spec.ts
@@ -1,0 +1,105 @@
+import { defineComponent } from "vue"
+import { shallowMount } from "@vue/test-utils"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  fetchNextPage: vi.fn(() => Promise.resolve()),
+  infiniteScrollCallback: undefined as undefined | (() => Promise<void>),
+  infiniteScrollDistance: 0,
+  hasNextPageRef: undefined as unknown as { value: boolean },
+  fetchingNextPageRef: undefined as unknown as { value: boolean },
+  productData: {
+    pages: [
+      {
+        count: 40,
+        next: "/inventory/catalog/?limit=20&offset=20",
+        results: [
+          { uid: "product-1", name: "Canvas Bag", images: [], variants: [] },
+          { uid: "product-2", name: "Smile Socks", images: [], variants: [] },
+        ],
+      },
+    ],
+  },
+}))
+
+vi.mock("@vueuse/core", () => ({
+  onClickOutside: vi.fn(),
+  useInfiniteScroll: (
+    _element: unknown,
+    callback: () => Promise<void>,
+    options: { distance: number },
+  ) => {
+    mocks.infiniteScrollCallback = callback
+    mocks.infiniteScrollDistance = options.distance
+  },
+}))
+vi.mock("@/composables/useDebouncedRef", () => ({ useDebouncedRef: (source: unknown) => source }))
+vi.mock("@/composables/useFormatCurrency", () => ({
+  useFormatCurrency: () => ({ format: (value: number) => `NGN ${value}` }),
+}))
+vi.mock("@modules/inventory/api", async () => {
+  const { ref } = await import("vue")
+  return {
+    useGetProductCatalogsInfinite: () => {
+      mocks.hasNextPageRef = ref(true)
+      mocks.fetchingNextPageRef = ref(false)
+      return {
+        data: ref(mocks.productData),
+        isPending: ref(false),
+        isFetchingNextPage: mocks.fetchingNextPageRef,
+        fetchNextPage: mocks.fetchNextPage,
+        hasNextPage: mocks.hasNextPageRef,
+      }
+    },
+    useGetCategories: () => ({ data: ref({ data: { results: [] } }), isFetching: ref(false) }),
+  }
+})
+
+import TargetSelector from "./TargetSelector.vue"
+
+const IconStub = defineComponent({
+  name: "Icon",
+  props: { name: String },
+  template: '<span :data-icon="name" />',
+})
+
+describe("TargetSelector product pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.infiniteScrollCallback = undefined
+    mocks.infiniteScrollDistance = 0
+  })
+
+  it("uses the shared infinite catalogue pagination and exposes next-page feedback", async () => {
+    const wrapper = shallowMount(TargetSelector, {
+      props: {
+        modelValue: {
+          mode: "products",
+          productUids: [],
+          variantSelections: {},
+          categoryUids: [],
+        },
+      },
+      global: { stubs: { Icon: IconStub } },
+    })
+
+    const productTrigger = wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Select at least one"))!
+    await productTrigger.trigger("click")
+    expect(wrapper.findAll("li")).toHaveLength(2)
+    expect(wrapper.text()).toContain("Canvas Bag")
+    expect(mocks.infiniteScrollDistance).toBe(80)
+
+    await mocks.infiniteScrollCallback?.()
+    expect(mocks.fetchNextPage).toHaveBeenCalledOnce()
+
+    mocks.fetchingNextPageRef.value = true
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain("Loading more products...")
+
+    mocks.hasNextPageRef.value = false
+    await mocks.infiniteScrollCallback?.()
+    expect(mocks.fetchNextPage).toHaveBeenCalledOnce()
+  })
+})

--- a/src/modules/discounts/components/TargetSelector.vue
+++ b/src/modules/discounts/components/TargetSelector.vue
@@ -54,7 +54,7 @@
             />
           </div>
 
-          <div class="max-h-72 overflow-auto">
+          <div ref="productListRef" class="max-h-72 overflow-auto">
             <div v-if="productsLoading" class="text-core-400 py-4 text-center text-sm">
               Loading products...
             </div>
@@ -92,6 +92,13 @@
                 </span>
               </li>
             </ul>
+            <div
+              v-if="isFetchingNextPage"
+              class="text-core-400 flex items-center justify-center gap-2 py-3 text-sm"
+            >
+              <Icon name="loader" size="16" class="text-primary-600 animate-spin" />
+              Loading more products...
+            </div>
           </div>
         </div>
       </div>
@@ -301,6 +308,7 @@ import Icon from "@components/Icon.vue"
 import ProductVariantPicker from "./ProductVariantPicker.vue"
 import { useFormatCurrency } from "@/composables/useFormatCurrency"
 import { useDebouncedRef } from "@/composables/useDebouncedRef"
+import { useInfinitePagination } from "@/composables/useInfinitePagination"
 import { useGetProductCatalogsInfinite, useGetCategories } from "@modules/inventory/api"
 import type { IProductCatalogue, IProductCategory } from "@modules/inventory/types"
 import { APPLIES_TO_OPTIONS } from "../constants"
@@ -389,10 +397,15 @@ onClickOutside(productDropdownRef, () => (productOpen.value = false))
 const productSearch = ref("")
 const debouncedProductSearch = useDebouncedRef(productSearch, 600)
 
-const { data: productsData, isPending: productsLoading } = useGetProductCatalogsInfinite(
-  20,
-  debouncedProductSearch,
-)
+const {
+  data: productsData,
+  isPending: productsLoading,
+  isFetchingNextPage,
+  fetchNextPage,
+  hasNextPage,
+} = useGetProductCatalogsInfinite(20, debouncedProductSearch)
+
+const productListRef = useInfinitePagination(fetchNextPage, hasNextPage, 80).el
 
 const products = computed<IProductCatalogue[]>(
   () => productsData.value?.pages?.flatMap((page) => page.results) ?? [],

--- a/src/modules/inventory/components/ManageStockModal.spec.ts
+++ b/src/modules/inventory/components/ManageStockModal.spec.ts
@@ -1,0 +1,128 @@
+import { defineComponent, reactive } from "vue"
+import { shallowMount } from "@vue/test-utils"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  resetForm: vi.fn(),
+  setFieldValue: vi.fn(),
+  stockChanged: vi.fn(),
+  transferChanged: vi.fn(),
+}))
+
+vi.mock("vee-validate", () => ({
+  useForm: () => ({
+    handleSubmit: (callback: (values: unknown) => unknown) => callback,
+    resetForm: mocks.resetForm,
+    values: reactive({
+      action: null,
+      quantity: 0,
+      unit_cost: "",
+      note: "",
+      loss_type: null,
+      to_location: null,
+    }),
+    setFieldValue: mocks.setFieldValue,
+  }),
+}))
+vi.mock("@vueuse/core", async () => {
+  const { ref } = await import("vue")
+  return { useMediaQuery: () => ref(false) }
+})
+vi.mock("@tanstack/vue-query", () => ({ useQueryClient: () => ({}) }))
+vi.mock("../api", async () => {
+  const { ref } = await import("vue")
+  const mutation = () => ({ mutate: vi.fn(), isPending: ref(false) })
+  return {
+    useAddStock: mutation,
+    useReduceStock: mutation,
+    useDirectStockTransfer: mutation,
+    useRequestStockTransfer: mutation,
+  }
+})
+vi.mock("../cache", () => ({
+  inventoryCache: {
+    stockChanged: mocks.stockChanged,
+    transferChanged: mocks.transferChanged,
+  },
+}))
+vi.mock("@modules/settings/store", () => ({
+  useSettingsStore: () => ({
+    activeLocation: { uid: "location-1", is_hq: true },
+    locations: [{ uid: "location-1", name: "HQ" }],
+  }),
+}))
+vi.mock("@/composables/useFormatCurrency", () => ({
+  useFormatCurrency: () => ({ format: (value: number) => `NGN ${value}` }),
+}))
+vi.mock("@/utils/product-attributes", () => ({
+  getProductAttributesForSelect: () => [],
+  findVariantByAttributes: () => null,
+}))
+vi.mock("../stock-form", () => ({
+  getAddStockDefaults: () => ({ recordExpense: true, note: "", unitCost: "" }),
+}))
+vi.mock("@/composables/useToast", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock("@/utils/error-handler", () => ({ displayError: vi.fn() }))
+
+import ManageStockModal from "./ManageStockModal.vue"
+import ManageStockSkeleton from "./skeletons/ManageStockSkeleton.vue"
+
+const ModalStub = defineComponent({
+  name: "Modal",
+  props: { open: Boolean, title: String },
+  emits: ["close"],
+  template: '<section v-if="open"><slot/><footer><slot name="footer"/></footer></section>',
+})
+
+describe("ManageStockModal loading contract", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("opens immediately with a skeleton until product details are available", async () => {
+    const wrapper = shallowMount(ManageStockModal, {
+      props: { open: true, product: null, loading: true },
+      global: { stubs: { Modal: ModalStub, Drawer: ModalStub } },
+    })
+
+    expect(wrapper.findComponent(ModalStub).props("open")).toBe(true)
+    expect(wrapper.findComponent(ManageStockSkeleton).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: "FormField" }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: "AppButton" }).exists()).toBe(false)
+
+    await wrapper.setProps({
+      loading: false,
+      product: {
+        uid: "product-1",
+        name: "Canvas Bag",
+        images: [],
+        variants: [
+          {
+            uid: "variant-1",
+            price: "5000",
+            sellable_stock: 10,
+            available_stock: 10,
+          },
+        ],
+      } as never,
+    })
+
+    expect(wrapper.findComponent(ManageStockSkeleton).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: "FormField" }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: "AppButton" }).exists()).toBe(true)
+    expect(mocks.resetForm).toHaveBeenCalled()
+  })
+
+  it("replaces a failed load with a retry action", () => {
+    const wrapper = shallowMount(ManageStockModal, {
+      props: { open: true, product: null, loading: false, error: true },
+      global: { stubs: { Modal: ModalStub, Drawer: ModalStub } },
+    })
+
+    expect(wrapper.findComponent(ManageStockSkeleton).exists()).toBe(false)
+    expect(wrapper.text()).toContain("Unable to load stock details")
+    const retry = wrapper
+      .findAllComponents({ name: "AppButton" })
+      .find((button) => button.props("label") === "Try Again")!
+    retry.vm.$emit("click")
+    expect(wrapper.emitted("retry")).toHaveLength(1)
+  })
+})

--- a/src/modules/inventory/components/ManageStockModal.vue
+++ b/src/modules/inventory/components/ManageStockModal.vue
@@ -8,7 +8,24 @@
     title="Manage Stock"
     @close="emit('close')"
   >
-    <div class="space-y-4">
+    <ManageStockSkeleton v-if="loading || (!product && !error)" />
+
+    <div
+      v-else-if="error && !product"
+      class="flex min-h-[360px] flex-col items-center justify-center gap-3 px-6 text-center"
+      role="alert"
+    >
+      <span class="bg-error-50 flex h-12 w-12 items-center justify-center rounded-full">
+        <Icon name="warning-2" size="24" class="text-error-600" />
+      </span>
+      <div class="space-y-1">
+        <h3 class="text-core-800 font-semibold">Unable to load stock details</h3>
+        <p class="text-core-500 text-sm">Check your connection and try again.</p>
+      </div>
+      <AppButton label="Try Again" variant="outlined" @click="emit('retry')" />
+    </div>
+
+    <div v-else class="space-y-4">
       <!-- Action Selector -->
       <FormField
         name="action"
@@ -28,7 +45,7 @@
             <img
               v-if="displayImage"
               :src="displayImage"
-              :alt="product.name"
+              :alt="product?.name ?? ''"
               class="h-full w-full object-cover"
             />
             <div v-else class="flex h-full w-full items-center justify-center">
@@ -37,7 +54,7 @@
           </div>
 
           <div class="flex h-full min-w-0 flex-1 flex-col justify-between gap-2">
-            <p class="truncate font-medium">{{ product.name }}</p>
+            <p class="truncate font-medium">{{ product?.name }}</p>
             <!-- Price and stock only show when variant is selected or for simple products -->
             <template v-if="showPriceAndStock">
               <div class="flex items-center gap-2">
@@ -200,6 +217,7 @@
 
     <template #footer>
       <AppButton
+        v-if="product && !loading"
         :label="submitButtonLabel"
         :loading="isPending"
         class="w-full"
@@ -222,6 +240,7 @@ import FormField from "@components/form/FormField.vue"
 import Chip from "@components/Chip.vue"
 import Icon from "@components/Icon.vue"
 import ExpenseRecordCard from "@modules/shared/components/ExpenseRecordCard.vue"
+import ManageStockSkeleton from "./skeletons/ManageStockSkeleton.vue"
 import {
   useAddStock,
   useReduceStock,
@@ -245,14 +264,21 @@ import { getAddStockDefaults } from "../stock-form"
 
 interface Props {
   open: boolean
-  product: IProductDetails
+  product?: IProductDetails | null
+  loading?: boolean
+  error?: boolean
 }
 
 interface Emits {
   (e: "close"): void
+  (e: "retry"): void
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  product: null,
+  loading: false,
+  error: false,
+})
 const emit = defineEmits<Emits>()
 const { format } = useFormatCurrency()
 
@@ -325,12 +351,12 @@ const locationOptions = computed(() => {
 
 // Check if product has multiple variants (complex product)
 const isComplexProduct = computed(() => {
-  return props.product.variants.length > 1
+  return (props.product?.variants?.length ?? 0) > 1
 })
 
 // Get product attributes for selection
 const productAttributes = computed(() => {
-  if (!isComplexProduct.value) return []
+  if (!props.product || !isComplexProduct.value) return []
   return getProductAttributesForSelect(props.product)
 })
 
@@ -457,6 +483,7 @@ const selectedAction = computed(() => values.action?.value)
 
 // Get selected variant based on attribute selection
 const selectedVariant = computed(() => {
+  if (!props.product) return null
   if (!isComplexProduct.value) {
     // Simple product - return the single variant
     return props.product.variants[0]
@@ -489,7 +516,7 @@ const displayImage = computed(() => {
   if (selectedVariant.value?.image) {
     return selectedVariant.value.image
   }
-  return props.product.images?.[0]?.image || null
+  return props.product?.images?.[0]?.image || null
 })
 
 // Get display price
@@ -542,31 +569,30 @@ const submitButtonLabel = computed(() => {
   }
 })
 
-// Reset form when modal opens
-watch(
-  () => props.open,
-  (isOpen) => {
-    if (isOpen) {
-      const defaults = getAddStockDefaults()
-      const initialValues: FormValues = {
-        action: null,
-        quantity: 0,
-        unit_cost: "",
-        note: "",
-        loss_type: null,
-        to_location: null,
-      }
-
-      // Reset attribute fields
-      productAttributes.value.forEach((attr) => {
-        initialValues[attr.attribute_uid] = null
-      })
-
-      resetForm({ values: initialValues })
-      recordExpense.value = defaults.recordExpense
+// Reset when the modal opens and again when asynchronously loaded product details
+// first become available. Watching the UID avoids resetting an in-progress form
+// during background refetches of the same product.
+watch([() => props.open, () => props.product?.uid], ([isOpen]) => {
+  if (isOpen) {
+    const defaults = getAddStockDefaults()
+    const initialValues: FormValues = {
+      action: null,
+      quantity: 0,
+      unit_cost: "",
+      note: "",
+      loss_type: null,
+      to_location: null,
     }
-  },
-)
+
+    // Reset attribute fields
+    productAttributes.value.forEach((attr) => {
+      initialValues[attr.attribute_uid] = null
+    })
+
+    resetForm({ values: initialValues })
+    recordExpense.value = defaults.recordExpense
+  }
+})
 
 // Only add-stock uses the purchase reason default. Other stock actions must not
 // inherit it when the merchant switches actions in the shared modal.
@@ -611,7 +637,7 @@ const onSubmit = handleSubmit((formValues) => {
 
     const onSuccess = () => {
       toast.success("Stock added successfully")
-      inventoryCache.stockChanged(queryClient, props.product.uid)
+      if (props.product) inventoryCache.stockChanged(queryClient, props.product.uid)
       emit("close")
     }
 
@@ -635,7 +661,7 @@ const onSubmit = handleSubmit((formValues) => {
 
     const onSuccess = () => {
       toast.success("Stock reduced successfully")
-      inventoryCache.stockChanged(queryClient, props.product.uid)
+      if (props.product) inventoryCache.stockChanged(queryClient, props.product.uid)
       emit("close")
     }
 
@@ -659,7 +685,9 @@ const onSubmit = handleSubmit((formValues) => {
     const onSuccess = () => {
       toast.success(`Stock ${action === "transfer" ? "transferred" : "request sent"} successfully`)
       // A direct transfer moves stock; a request only creates a transfer request.
-      inventoryCache.transferChanged(queryClient, action === "transfer", props.product.uid)
+      if (props.product) {
+        inventoryCache.transferChanged(queryClient, action === "transfer", props.product.uid)
+      }
       emit("close")
     }
 

--- a/src/modules/inventory/components/skeletons/ManageStockSkeleton.vue
+++ b/src/modules/inventory/components/skeletons/ManageStockSkeleton.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="min-h-[360px] animate-pulse space-y-4" aria-label="Loading stock details">
+    <div class="space-y-2">
+      <div class="h-4 w-24 rounded bg-gray-200" />
+      <div class="h-11 w-full rounded-xl bg-gray-200" />
+    </div>
+
+    <div class="rounded-xl border border-gray-200 bg-white p-4">
+      <div class="flex items-center gap-3">
+        <div class="h-14 w-14 shrink-0 rounded-md bg-gray-200" />
+        <div class="flex-1 space-y-2">
+          <div class="h-4 w-2/5 rounded bg-gray-200" />
+          <div class="h-4 w-1/4 rounded bg-gray-200" />
+        </div>
+        <div class="h-7 w-24 rounded-full bg-gray-200" />
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <div class="h-4 w-28 rounded bg-gray-200" />
+      <div class="h-11 w-full rounded-xl bg-gray-200" />
+    </div>
+
+    <div class="space-y-2">
+      <div class="h-4 w-20 rounded bg-gray-200" />
+      <div class="h-24 w-full rounded-xl bg-gray-200" />
+    </div>
+  </div>
+</template>

--- a/src/modules/inventory/views/index.vue
+++ b/src/modules/inventory/views/index.vue
@@ -293,10 +293,12 @@
       @close="showReceiveRequestModal = false"
     />
     <ManageStockModal
-      v-if="productDetailsForStock?.data"
       :open="showManageStockModal"
-      :product="productDetailsForStock.data"
+      :product="productDetailsForStock?.data ?? null"
+      :loading="isLoadingProductDetailsForStock && !productDetailsForStock?.data"
+      :error="isProductDetailsForStockError && !productDetailsForStock?.data"
       @close="showManageStockModal = false"
+      @retry="refetchProductDetailsForStock()"
     />
   </div>
 </template>
@@ -473,9 +475,17 @@ const productUidForEdit = ref<string | null>(null)
 // (not the modal-open flag) so the query stays active through the post-mutation
 // refetch and isn't disabled in the same tick the cache is invalidated (LYW-2647).
 const productUidForFetch = computed(() => productUidForManageStock.value || "")
-const { data: productDetailsForStock } = useGetProduct(productUidForFetch, {
+const {
+  data: productDetailsForStock,
+  isPending: isPendingProductDetailsForStock,
+  isError: isProductDetailsForStockError,
+  refetch: refetchProductDetailsForStock,
+} = useGetProduct(productUidForFetch, {
   enabled: () => !!productUidForManageStock.value,
 })
+const isLoadingProductDetailsForStock = computed(
+  () => !!productUidForManageStock.value && isPendingProductDetailsForStock.value,
+)
 
 // Fetch product details for edit drawer when needed
 const productUidForEditFetch = computed(() => productUidForEdit.value || "")


### PR DESCRIPTION
## What changed

- open Manage Stock immediately and render a dedicated skeleton while product details load
- show a retryable error state if stock details cannot be fetched
- keep the loaded stock form stable during background refetches
- paginate discount and coupon product selectors as users scroll
- show next-page loading feedback inside the product dropdown
- add focused regression tests for both flows

## Why

Manage Stock was conditionally mounted only after its product-detail request completed, so users received no immediate feedback after clicking the action. The product target selector already used the inventory infinite query, but it did not connect `fetchNextPage` to its scroll container, limiting the visible catalogue to the first 20 products.

## Maintenance impact

The stock modal now owns its loading and failure states, matching the established Manage Variants drawer pattern. Product pagination reuses the same inventory query keys, TanStack cache, and `useInfinitePagination` composable used by Orders and Popups; no second product cache or API contract was introduced. Because discounts and coupons share `TargetSelector`, both targeting flows receive the pagination fix.

## Validation

- `npm run test:run` — 21 files / 147 tests passed
- `npm run lint`
- `npm run build`
