### PR TITLE
fix: share only the link for invoice/payment link, use runtime origin in prod, require cost price for stocked items

### DIFF
--- a/src/modules/inventory/composables/useVariantValidation.ts
+++ b/src/modules/inventory/composables/useVariantValidation.ts
@@ -148,6 +148,13 @@ export function useVariantValidation(options: IVariantValidationOptions) {
     return Number.isInteger(num) && num >= 0
   }
 
+  /** A variant "has stock" when its opening stock parses to a positive quantity. */
+  const hasStockQuantity = (value: string): boolean => {
+    if (!value || value.trim() === "") return false
+    const num = Number(value)
+    return Number.isFinite(num) && num > 0
+  }
+
   const buildProductDetailsValidation = (): ICurrentProductStepValidation => {
     const errors = EMPTY_PRODUCT_DETAILS_ERRORS()
     let firstErrorTarget: string | undefined
@@ -238,6 +245,12 @@ export function useVariantValidation(options: IVariantValidationOptions) {
     requirePrice: boolean
     requireWeight: boolean
     requireDimensions: boolean
+    /**
+     * Whether a cost price is compulsory for variants carrying stock. Only enabled where the
+     * field is actually editable — the edit drawer disables cost price in most modes, and
+     * requiring a disabled field would make the drawer impossible to submit.
+     */
+    requireCostPrice: boolean
   }): ICurrentProductStepValidation => {
     const errors = EMPTY_INVENTORY_ERRORS(variants.value.length)
     let firstErrorTarget: string | undefined
@@ -282,11 +295,17 @@ export function useVariantValidation(options: IVariantValidationOptions) {
         firstErrorTarget ??= `variant-opening-stock-${index}`
       }
 
+      // Cost price is compulsory for every variant that carries stock. Simple products validate
+      // here too — they are represented as a single variant — so this covers both simple and
+      // variable products. Variants with no stock may still leave it blank.
       if (variant.cost_price && variant.cost_price.trim() !== "") {
         if (!isValidNonNegativeNumber(variant.cost_price)) {
           errors.variants[index].cost_price = "Enter a valid cost price."
           firstErrorTarget ??= `variant-cost-price-${index}`
         }
+      } else if (config.requireCostPrice && hasStockQuantity(variant.opening_stock)) {
+        errors.variants[index].cost_price = "Enter a cost price for items with stock."
+        firstErrorTarget ??= `variant-cost-price-${index}`
       }
 
       if (config.requirePrice && !isValidNonNegativeNumber(variant.price)) {
@@ -324,6 +343,9 @@ export function useVariantValidation(options: IVariantValidationOptions) {
         requirePrice: true,
         requireWeight,
         requireDimensions: requireWeight,
+        // The edit drawer disables cost price outside the new-variant pricing handoff, and this
+        // step doesn't collect stock, so it stays optional here.
+        requireCostPrice: false,
       })
     }
 
@@ -357,6 +379,7 @@ export function useVariantValidation(options: IVariantValidationOptions) {
         requirePrice: true,
         requireWeight: true,
         requireDimensions: true,
+        requireCostPrice: true,
       })
     }
 

--- a/src/modules/orders/views/index.vue
+++ b/src/modules/orders/views/index.vue
@@ -285,24 +285,20 @@ const { mutate: generateReceipt } = useGenerateReceipt()
 const { mutate: generateInvoice } = useGenerateInvoice()
 const { mutate: markAsPaid, isPending: isMarkingPaid } = useMarkOrderAsPaid()
 
-// Get invoice link for an order
-const getInvoiceLink = (order: TOrder) => {
-  const isLocal = window.location.hostname === "localhost"
-  return isLocal
-    ? `http://localhost:8080/pay/${order.order_number}`
-    : `https://suite-v2.vercel.app/pay/${order.order_number}`
-}
+// Get invoice link for an order. The /pay/:id route is served by this same app, so the link is
+// derived from the current origin — correct on localhost, staging and production alike. The old
+// hardcoded staging host (suite-v2.vercel.app) leaked into production payment links.
+const getInvoiceLink = (order: TOrder) => `${window.location.origin}/pay/${order.order_number}`
 
 // Share payment link using Web Share API
 const handleSharePaymentLink = async (order: TOrder) => {
   const link = getInvoiceLink(order)
   if (navigator.share) {
     try {
-      await navigator.share({
-        title: `Payment Link for Order #${order.order_number}`,
-        text: `Complete your payment for order #${order.order_number}`,
-        url: link,
-      })
+      // Share the bare URL only. Picking "Copy" in the native share sheet concatenates
+      // title/text with the url, which would put extra prose on the clipboard instead of
+      // just the link.
+      await navigator.share({ url: link })
     } catch {
       // User cancelled or share failed, fallback to copy
       navigator.clipboard.writeText(link).then(() => {
@@ -357,17 +353,13 @@ const handleShareInvoice = (order: TOrder): Promise<void> => {
       onSuccess: (response) => {
         const invoiceUrl = response.data?.data.url as string | undefined
         if (invoiceUrl && navigator.share) {
-          navigator
-            .share({
-              title: `Invoice for Order #${order.order_number}`,
-              text: `Invoice for order #${order.order_number}`,
-              url: invoiceUrl,
+          // Share the bare URL only — see handleSharePaymentLink: title/text would end up on
+          // the clipboard alongside the link when the user picks "Copy".
+          navigator.share({ url: invoiceUrl }).catch(() => {
+            navigator.clipboard.writeText(invoiceUrl).then(() => {
+              toast.info("Invoice link copied to clipboard!")
             })
-            .catch(() => {
-              navigator.clipboard.writeText(invoiceUrl).then(() => {
-                toast.info("Invoice link copied to clipboard!")
-              })
-            })
+          })
         } else if (invoiceUrl) {
           navigator.clipboard.writeText(invoiceUrl).then(() => {
             toast.info("Invoice link copied to clipboard!")


### PR DESCRIPTION
Three hotfixes: two for the order **share** actions, one for product **cost price** validation.

## 1. Copy now yields only the link (Share invoice + Share payment link)
Both share actions passed `title`, `text` **and** `url` to `navigator.share()`. When the merchant picks **Copy** in the native share sheet, the OS concatenates the title/text with the URL, so the clipboard ended up with prose like `Payment Link for Order #1234 Complete your payment for order #1234 https://…` instead of just the link.

Both now share the bare URL only, so **Copy** puts nothing but the link on the clipboard. The existing explicit clipboard fallbacks already copied only the URL and are unchanged.

## 2. Payment link no longer uses the staging host in production
`getInvoiceLink()` hardcoded `https://suite-v2.vercel.app/pay/<order>` for every non-localhost environment, so **production payment links pointed at staging**.

Since `/pay/:id` is served by this same app, the link is now derived from `window.location.origin` — correct on localhost, Vercel previews, staging and production (`suite.leyyow.com`) with no new env var and no host to keep in sync.

## 3. Cost price is now compulsory for products/variants with stock
The cost price field was rendered with `required` in the product form, but nothing validated it — a product could be created with stock and no cost price, which breaks margin/COGS reporting.

Cost price is now required whenever a variant carries a **positive opening stock**:
- **Simple products** — validated as a single variant, so covered by the same rule.
- **Variable products** — enforced per variant, so only the stocked variants are flagged.
- Variants with **0 stock** may still leave it blank.
- An invalid (non-numeric) cost price keeps its existing "Enter a valid cost price." error; a blank one on a stocked variant now shows "Enter a cost price for items with stock."

The error surfaces on the offending field and drives the existing scroll-to-first-error behaviour, since `variant-cost-price-<index>` targets and error bindings were already wired up in the form.

**Deliberately scoped:** the requirement is only enabled where the field is editable. The edit drawer disables cost price outside the new-variant pricing handoff, and requiring a disabled field would make that drawer impossible to submit. The quick-add product modal in the order flow already required cost price via its Yup schema, so it needed no change.

## Scope note
`handleShareReceipt` (**Share receipt**) has the identical `title`/`text` issue as #1, but it was not part of this request so it is deliberately left unchanged. Happy to include it here or in a follow-up.

## Verification
`npm run lint` and `npm run build` (`vue-tsc` typecheck) pass after each change.
