### PR TITLE
fix: copy only the link when sharing an order receipt

### DIFF
--- a/src/modules/orders/views/index.vue
+++ b/src/modules/orders/views/index.vue
@@ -320,17 +320,13 @@ const handleShareReceipt = (order: TOrder): Promise<void> => {
       onSuccess: (response) => {
         const receiptUrl = response.data?.data.url as string | undefined
         if (receiptUrl && navigator.share) {
-          navigator
-            .share({
-              title: `Receipt for Order #${order.order_number}`,
-              text: `Receipt for order #${order.order_number}`,
-              url: receiptUrl,
+          // Share the bare URL only — see handleSharePaymentLink: title/text would end up on
+          // the clipboard alongside the link when the user picks "Copy".
+          navigator.share({ url: receiptUrl }).catch(() => {
+            navigator.clipboard.writeText(receiptUrl).then(() => {
+              toast.info("Receipt link copied to clipboard!")
             })
-            .catch(() => {
-              navigator.clipboard.writeText(receiptUrl).then(() => {
-                toast.info("Receipt link copied to clipboard!")
-              })
-            })
+          })
         } else if (receiptUrl) {
           navigator.clipboard.writeText(receiptUrl).then(() => {
             toast.info("Receipt link copied to clipboard!")


### PR DESCRIPTION
Follow-up to #162, which fixed the same bug for **Share invoice** and **Share payment link**.

## The problem
`handleShareReceipt` passed `title`, `text` **and** `url` to `navigator.share()`. When the merchant picks **Copy** in the native share sheet, the OS concatenates the title/text with the URL, so the clipboard ended up with prose like:

```
Receipt for Order #1234 Receipt for order #1234 https://…
```

instead of just the link.

## The fix
Share the bare URL only, so **Copy** puts nothing but the link on the clipboard. This brings **Share receipt** in line with the invoice and payment-link behaviour already shipped in #162 — all three share actions now copy only the link.

The existing explicit clipboard fallbacks (no Web Share API, or share cancelled) already copied only the URL and are unchanged.

## Verification
`npm run lint` and `npm run build` (`vue-tsc` typecheck) pass.
